### PR TITLE
Robots override option

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,5 +13,12 @@ export default defineConfig({
       plugins: [tailwindcss()],
     },
     site: CONFIG.URL,
-    integrations: [sitemap(), robotsTxt()],
+    integrations: [
+      sitemap(), 
+      robotsTxt({
+        transform(content) {
+          return `${CONFIG.ROBOTS_OVERRIDE || content}`;        
+        },
+      }),
+    ],
   });

--- a/src/config/config.example.js
+++ b/src/config/config.example.js
@@ -45,4 +45,17 @@ export const CONFIG = {
 
     SCHEDULED_POSTS: true, // true/1 or false/0. POSTS WITH FUTURE dateCreated WILL BE HIDDEN UNTIL PUBLISH DATE
     SCHEDULED_POSTS_SEE_IN_DEV: true, // true/1 or false/0. SHOW SCHEDULED POSTS IN DEV MODE
+      
+    // ROBOTS.TXT //
+    // Set to blank string/remove to use default.
+    // Default is:
+    //// User-agent: *
+    //// Allow: /
+    //// Sitemap: CONFIG.URL (as set above)
+
+    // Making changes in astro.config.mjs will break config option, but might be required for more specific use cases.
+    // See https://www.npmjs.com/package/astro-robots-txt#usage for more info.
+    ROBOTS_OVERRIDE: "User-agent: *\nDisallow: /\nSitemap: https://nought.vercel.app/sitemap-index.xml" // OVERRIDE FOR ROBOTS.TXT. DEFAULTS TO 'User-agent: *'
 };
+
+

--- a/src/config/config.example.js
+++ b/src/config/config.example.js
@@ -55,7 +55,7 @@ export const CONFIG = {
 
     // Making changes in astro.config.mjs will break config option, but might be required for more specific use cases.
     // See https://www.npmjs.com/package/astro-robots-txt#usage for more info.
-    ROBOTS_OVERRIDE: "User-agent: *\nDisallow: /\nSitemap: https://nought.vercel.app/sitemap-index.xml" // OVERRIDE FOR ROBOTS.TXT. DEFAULTS TO 'User-agent: *'
+    ROBOTS_OVERRIDE: "User-agent: *\nDisallow: /\nSitemap: https://nought.vercel.app/sitemap-index.xml"
 };
 
 


### PR DESCRIPTION
Added new config option: `ROBOTS_OVERRIDE`. Probably don't need quite as much explainer text, but it's a pretty unfriendly config option (i.e. if someone uses defaults, they'll have the wrong domain set, and will block all robots).

Solution could be a utility function to generate `config.js` from example options, removing anything specific to the demo site.

```
    // ROBOTS.TXT //
    // Set to blank string/remove to use default.
    // Default is:
    //// User-agent: *
    //// Allow: /
    //// Sitemap: CONFIG.URL (as set above)

    // Making changes in astro.config.mjs will break config option, but might be required for more specific use cases.
    // See https://www.npmjs.com/package/astro-robots-txt#usage for more info.
    ROBOTS_OVERRIDE: "User-agent: *\nDisallow: /\nSitemap: https://nought.vercel.app/sitemap-index.xml"
```
`robotsTxt` config in `astro.config.mjs` will render the override if present, else will revert to the default.
```
robotsTxt({
        transform(content) {
          return `${CONFIG.ROBOTS_OVERRIDE || content}`;        
        },
      }),
```