### PR TITLE
Remote images infersize fix

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,15 +16,20 @@ import ecConfig from "./ec.config.mjs";
 // TODO: fallback to src/posts is set in 4 different locations. Move into configLoader.
 const postsDir = CONFIG.POSTS_DIR ?? "src/posts";
 
+const imageConfig =
+  // Check if user is bypassing the warning by setting IMAGE_REMOTE_DOMAINS to 'unsafe'.
+  CONFIG.IMAGE_REMOTE_DOMAINS === "unsafe"
+    // If so, allow all remote images by using remotePatterns
+    ? { remotePatterns: [{ protocol: "https" }, { protocol: "http" }] }
+    // Otherwise, check that an array of domains (or blank array) has been provided
+    : CONFIG.IMAGE_REMOTE_DOMAINS instanceof Array
+      ? { domains: CONFIG.IMAGE_REMOTE_DOMAINS }
+      // If anything else is set, use a blank array to prevent errors.
+      : { domains: [] };
+
 // https://astro.build/config
 export default defineConfig({
-  image: {
-    // check that CONFIG.IMAGE_REMOTE_DOMAINS is an array, else set empty array
-    domains:
-      CONFIG.IMAGE_REMOTE_DOMAINS instanceof Array
-        ? CONFIG.IMAGE_REMOTE_DOMAINS
-        : [],
-  },
+  image: imageConfig,
   vite: {
     plugins: [
       tailwindcss(),

--- a/src/config/config.example.js
+++ b/src/config/config.example.js
@@ -123,7 +123,16 @@ export const CONFIG = {
 
   // IMAGE SETTINGS //
   // LIST OF DOMAINS FOR ASTRO IMAGE OPTIMIZATION
-  IMAGE_REMOTE_DOMAINS: [], // NOTE: [''] essentially wildcards all remote images. Use empty array, or comment out to disable.
+  // Use an array of hostnames to allow specific domains: ['images.unsplash.com', 'cdn.example.com']
+  // Astro 5.17.3 fixed a bug which allowed all remote image domains to be optimised without checking the allowlist.
+  // https://github.com/withastro/docs/pull/13282:
+  // > "It's no longer true that inferSize will fetch unauthorized images. Allowing this exposes a
+  // > vulnerability with internal services, so we now check image.domains."
+  //
+  // ^^ that's your warning. While there is less of a risk for SSGs, you should still
+  // think twice before bypassing this, but setting IMAGE_REMOTE_DOMAINS: 'unsafe' will allow all.
+  // Use [] or omit to disable remote images entirely.
+  IMAGE_REMOTE_DOMAINS: ['images.unsplash.com'],
 
   // STYLING OVERRIDES //
   // CSS/TAILWINDCSS/DAISYUI CLASSES/OVERRIDES


### PR DESCRIPTION
#108 failed to build.

https://docs.astro.build/en/reference/modules/astro-assets/#:~:text=Here%20are%20some%20properties%20of%20the%20component:,attributes%20to%20be%20added%20to%20the%20tag

> As of Astro 5.17.3, inferSize only fetches dimensions for authorized remote image domains. Remote images outside the allowlist are not fetched.

See: https://github.com/withastro/astro/pull/15569