### PR TITLE
Add support for Astro v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "updates": "^17.9.0"
       },
       "devDependencies": {
-        "@igor.dvlpr/astro-post-excerpt": "^4.0.0",
+        "@igor.dvlpr/astro-post-excerpt": "4.1.1-alpha.0",
         "@tailwindcss/typography": "^0.5.19",
         "del-cli": "^7.0.0",
         "prettier-plugin-astro": "^0.14.1",
@@ -717,14 +717,14 @@
       }
     },
     "node_modules/@igor.dvlpr/astro-post-excerpt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@igor.dvlpr/astro-post-excerpt/-/astro-post-excerpt-4.0.0.tgz",
-      "integrity": "sha512-rm7ToXWq0efk4TEzNRhAjR7slPWRRJIxufLOyYHFn/F5979Gzv669p64SbNboCU2zctXKbkHU8dh4iF2Jb09Dg==",
+      "version": "4.1.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@igor.dvlpr/astro-post-excerpt/-/astro-post-excerpt-4.1.1-alpha.0.tgz",
+      "integrity": "sha512-QGzLdEsU5h2UpSlquTNm0KA2S9ID4Mo9qE2T6IQDFhADBnrUZFCQ3g3hrCtllHhfVeClgSj55o5zLfknfvTe+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@igor.dvlpr/strip-yaml-front-matter": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.2",
+        "@igorskyflyer/strip-yaml-front-matter": "^1.1.1",
+        "mdast-util-from-markdown": "^2.0.3",
         "mdast-util-mdx": "^3.0.0",
         "micromark-extension-mdxjs": "^3.0.0"
       },
@@ -735,17 +735,17 @@
         "url": "https://ko-fi.com/igorskyflyer"
       },
       "peerDependencies": {
-        "astro": "^5.0.0"
+        "astro": ">=5.0.0"
       }
     },
-    "node_modules/@igor.dvlpr/strip-yaml-front-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@igor.dvlpr/strip-yaml-front-matter/-/strip-yaml-front-matter-1.0.0.tgz",
-      "integrity": "sha512-SZjJC9p3X7TPEgwjCLYYfE21JAXptcITvwMZnmcJ14vzPiUsduNPykoPGCQw8Tu04lJ0dgyg0CmSeL78b7OFEQ==",
+    "node_modules/@igorskyflyer/strip-yaml-front-matter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@igorskyflyer/strip-yaml-front-matter/-/strip-yaml-front-matter-1.1.1.tgz",
+      "integrity": "sha512-3oc1BDqn2lXDFQDdvqqBQVHU8pWLhgVyPU7xXmTpLKruPxN6qLLGIE3intf+iXDS7fFAEcXtMctOdaNiW1nvlg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.0"
+        "node": ">=22.0"
       },
       "funding": {
         "url": "https://ko-fi.com/igorskyflyer"
@@ -4919,9 +4919,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "updates": "^17.9.0"
   },
   "devDependencies": {
-    "@igor.dvlpr/astro-post-excerpt": "^4.0.0",
+    "@igor.dvlpr/astro-post-excerpt": "4.1.1-alpha.0",
     "@tailwindcss/typography": "^0.5.19",
     "del-cli": "^7.0.0",
     "prettier-plugin-astro": "^0.14.1",


### PR DESCRIPTION
> v4.1.0 (14-Mar-2026)
✨ feat: add support for Astro v6
⚠️ Important notice – End of life under this scope This is the last version that will be published under @igor.dvlpr/astro-post-excerpt.

> Future updates, bug fixes, and new features will be released under a new package scope of @igorskyflyer. Please plan to migrate to the new package once released.

> Why?
Technical issues and maintenance reasons (scope consolidation, better discoverability, and alignment with other projects)."

4.1.0 doesn't appear to be a full release.