### PR TITLE
Collapse ToC sooner

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -61,7 +61,7 @@ const filtered = headings.filter(
     data-toc-desktop
     data-min-depth={min_depth}
     data-max-depth={max_depth}
-    class="hidden lg:block w-64 shrink-0 mt-[200px]"
+    class="hidden xl:block w-64 shrink-0 mt-[200px]"
   >
     <div class={`nought-stroke sticky top-10 max-h-[calc(100vh-5rem)] bg-base-300 overflow-y-auto shadow-[4px_4px_0px_0px] hover:shadow-[0px_0px_0px_0px] px-2 py-1 border-2 rounded-field bg-base-100 text-base-content border-base-content shadow-base-content transition-shadow duration-300 ease-in-out ${toc_desktop_style_overrides}`}>
       {

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -126,7 +126,7 @@ const optimised_image = data.image
           {
             // Table of Contents - Mobile (top of article)
             toc_enable && toc_headings?.length >= toc_min_heading_qty ? (
-              <div class="block lg:hidden">
+              <div class="block xl:hidden">
                 <TableOfContents
                   headings={headings}
                   min_depth={toc_min_depth}


### PR DESCRIPTION
ToC was causing content to be hidden behind the menu drawer and wasn't collapsing until it reached lg width. Now set to xl.